### PR TITLE
Support Ubuntu 22.04 GitHub Actions runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         run: docker build -t docker-ansible .
 
       - name: Run the built image.
-        run: docker run --name test-container -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro docker-ansible
+        run: docker run --name test-container -d --privileged --cgroupns host -v /sys/fs/cgroup:/sys/fs/cgroup:rw docker-ansible
 
       - name: Verify Ansible is accessible in the built image.
         run: docker exec --tty test-container env TERM=xterm ansible --version

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This image is built on Docker Hub automatically any time the upstream OS contain
 
   1. [Install Docker](https://docs.docker.com/engine/installation/).
   2. Pull this image from Docker Hub: `docker pull geerlingguy/docker-fedora35-ansible:latest` (or use the image you built earlier, e.g. `fedora35-ansible:latest`).
-  3. Run a container from the image: `docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro geerlingguy/docker-fedora35-ansible:latest` (to test my Ansible roles, I add in a volume mounted from the current working directory with ``--volume=`pwd`:/etc/ansible/roles/role_under_test:ro``).
+  3. Run a container from the image: `docker run --detach --privileged --cgroupns=host --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw geerlingguy/docker-fedora35-ansible:latest` (to test my Ansible roles, I add in a volume mounted from the current working directory with ``--volume=`pwd`:/etc/ansible/roles/role_under_test:ro``).
   4. Use Ansible inside the container:
     a. `docker exec --tty [container_id] env TERM=xterm ansible --version`
     b. `docker exec --tty [container_id] env TERM=xterm ansible-playbook /path/to/ansible/playbook.yml --syntax-check`


### PR DESCRIPTION
These changes should fix the currently failing GitHub Actions configuration now that Ubuntu 22.04 runners are being used for your workflows using the `ubuntu-latest` tag. These mirror the changes made in [geerlingguy/docker-fedora37-ansible#2](https://github.com/geerlingguy/docker-fedora37-ansible/pull/2).